### PR TITLE
Add custom property ProviderType to AzureDevOpsPullRequestCommentThread

### DIFF
--- a/src/Cake.Issues.PullRequests.AzureDevOps.Tests/Capabilities/GitPullRequestCommentThreadExtensionsTests.cs
+++ b/src/Cake.Issues.PullRequests.AzureDevOps.Tests/Capabilities/GitPullRequestCommentThreadExtensionsTests.cs
@@ -242,6 +242,32 @@
                 result.CommentSource.ShouldBe(commentSource);
             }
 
+            [Fact]
+            public void Should_Set_Correct_ProviderType()
+            {
+                // Given
+                var id = 123;
+                var status = AzureDevOpsCommentThreadStatus.Active;
+                var filePath = "/foo.cs";
+                var providerType = "foo";
+                var thread =
+                    new AzureDevOpsPullRequestCommentThread
+                    {
+                        Id = id,
+                        Status = status,
+                        FilePath = filePath,
+                        Comments = new List<AzureDevOpsComment>(),
+                        Properties = new Dictionary<string, object>(),
+                    };
+                thread.SetProviderType(providerType);
+
+                // When
+                var result = thread.ToPullRequestDiscussionThread();
+
+                // Then
+                result.ProviderType.ShouldBe(providerType);
+            }
+
             [Theory]
             [InlineData(
                 AzureDevOpsCommentThreadStatus.Unknown,
@@ -349,6 +375,66 @@
             }
         }
 
+        public sealed class TheGetProviderTypeExtension
+        {
+            [Fact]
+            public void Should_Throw_If_Thread_Is_Null()
+            {
+                // Given
+                AzureDevOpsPullRequestCommentThread thread = null;
+
+                // When
+                var result = Record.Exception(() => thread.GetProviderType());
+
+                // Then
+                result.IsArgumentNullException("thread");
+            }
+
+            [Fact]
+            public void Should_Not_Throw_If_Properties_Are_Null()
+            {
+                // Given
+                var thread =
+                    new AzureDevOpsPullRequestCommentThread
+                    {
+                        Id = 123,
+                        Status = AzureDevOpsCommentThreadStatus.Active,
+                        FilePath = "/foo.cs",
+                        Comments = new List<AzureDevOpsComment>(),
+                        Properties = null,
+                    };
+
+                // When
+                var result = thread.GetProviderType();
+
+                // Then
+                result.ShouldBe(default);
+            }
+
+            [Fact]
+            public void Should_Return_ProviderType()
+            {
+                // Given
+                var providerType = "fooProv";
+                var thread =
+                    new AzureDevOpsPullRequestCommentThread
+                    {
+                        Id = 123,
+                        Status = AzureDevOpsCommentThreadStatus.Active,
+                        FilePath = "/foo.cs",
+                        Comments = new List<AzureDevOpsComment>(),
+                        Properties = new Dictionary<string, object>(),
+                    };
+                thread.SetProviderType(providerType);
+
+                // When
+                var result = thread.GetProviderType();
+
+                // Then
+                result.ShouldBe(providerType);
+            }
+        }
+
         public sealed class TheSetCommentSourceExtension
         {
             [Fact]
@@ -407,6 +493,67 @@
 
                 // Then
                 thread.GetCommentSource().ShouldBe(commentSource);
+            }
+        }
+
+        public sealed class TheSetProviderTypeExtension
+        {
+            [Fact]
+            public void Should_Throw_If_Thread_Is_Null()
+            {
+                // Given
+                AzureDevOpsPullRequestCommentThread thread = null;
+                var value = "foo";
+
+                // When
+                var result = Record.Exception(() => thread.SetProviderType(value));
+
+                // Then
+                result.IsArgumentNullException("thread");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Properties_Are_Null()
+            {
+                // Given
+                var thread =
+                    new AzureDevOpsPullRequestCommentThread
+                    {
+                        Id = 123,
+                        Status = AzureDevOpsCommentThreadStatus.Active,
+                        FilePath = "/foo.cs",
+                        Comments = new List<AzureDevOpsComment>(),
+                        Properties = null,
+                    };
+                var value = "foo";
+
+                // When
+                var result = Record.Exception(() => thread.SetProviderType(value));
+
+                // Then
+                result.IsInvalidOperationException("Properties collection is not created.");
+            }
+
+            [Fact]
+            public void Should_Set_ProviderType()
+            {
+                // Given
+                var providerType = "provType";
+                var thread =
+                    new AzureDevOpsPullRequestCommentThread
+                    {
+                        Id = 123,
+                        Status = AzureDevOpsCommentThreadStatus.Active,
+                        FilePath = "/foo.cs",
+                        Comments = new List<AzureDevOpsComment>(),
+                        Properties = new Dictionary<string, object>(),
+                    };
+
+                // When
+                thread.SetProviderType(providerType);
+
+                // Then
+                thread.GetProviderType().ShouldBe(providerType);
             }
         }
 

--- a/src/Cake.Issues.PullRequests.AzureDevOps.Tests/Properties/AssemblyInfo.cs
+++ b/src/Cake.Issues.PullRequests.AzureDevOps.Tests/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/src/Cake.Issues.PullRequests.AzureDevOps.sln.DotSettings
+++ b/src/Cake.Issues.PullRequests.AzureDevOps.sln.DotSettings
@@ -1,3 +1,8 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeThisQualifier/@EntryIndexedValue">DO_NOT_SHOW</s:String>
-	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String></wpf:ResourceDictionary>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/ThisQualifier/INSTANCE_MEMBERS_QUALIFY_MEMBERS/@EntryValue">Field, Property</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/TRAILING_COMMA_IN_MULTILINE_LISTS/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/AddImportsToDeepestScope/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/QualifiedUsingAtNestedScope/@EntryValue">True</s:Boolean>
+	</wpf:ResourceDictionary>

--- a/src/Cake.Issues.PullRequests.AzureDevOps/AzureDevOpsPullRequestSystem.cs
+++ b/src/Cake.Issues.PullRequests.AzureDevOps/AzureDevOpsPullRequestSystem.cs
@@ -241,6 +241,9 @@
             // Add custom property for identifying the comment for subsequent runs
             thread.SetCommentIdentifier(issue.Identifier);
 
+            // Add a custom property to be able to distinguish all comments by provider type later on
+            thread.SetProviderType(issue.ProviderType);
+
             // Add a custom property to be able to return issue message from existing threads,
             // without any formatting done by this addin, back to Cake.Issues.PullRequests.
             thread.SetIssueMessage(issue.MessageText);

--- a/src/Cake.Issues.PullRequests.AzureDevOps/Capabilities/AzureDevOpsPullRequestCommentThreadExtensions.cs
+++ b/src/Cake.Issues.PullRequests.AzureDevOps/Capabilities/AzureDevOpsPullRequestCommentThreadExtensions.cs
@@ -11,6 +11,7 @@
         private const string CommentSourcePropertyName = "CakeIssuesCommentSource";
         private const string CommentIdentifierPropertyName = "CakeIssuesCommentIdentifier";
         private const string IssueMessagePropertyName = "CakeIssuesIssueMessage";
+        private const string ProviderTypePropertyName = "CakeIssuesProviderType";
 
         /// <summary>
         /// Converts a <see cref="AzureDevOpsPullRequestCommentThread"/> from Azure DevOps to a <see cref="IPullRequestDiscussionThread"/> as used in this addin.
@@ -29,12 +30,13 @@
             {
                 CommentSource = thread.GetCommentSource(),
                 CommentIdentifier = thread.GetCommentIdentifier(),
+                ProviderType = thread.GetProviderType(),
                 Resolution = thread.Status.ToPullRequestDiscussionResolution(),
             };
         }
 
         /// <summary>
-        /// Gets the comment source value used to decorate comments created by this addin.
+        /// Gets the comment source value used to decorate comments created by this add-in.
         /// </summary>
         /// <param name="thread">Thread to get the value from.</param>
         /// <returns>Comment source value.</returns>
@@ -46,7 +48,7 @@
         }
 
         /// <summary>
-        /// Sets the comment sourc e value used to decorate comments created by this addin.
+        /// Sets the comment source value used to decorate comments created by this addin.
         /// </summary>
         /// <param name="thread">Thread for which the value should be set.</param>
         /// <param name="value">Value to set as comment source.</param>
@@ -118,6 +120,30 @@
             thread.NotNull(nameof(thread));
 
             thread.SetValue(IssueMessagePropertyName, value);
+        }
+
+        /// <summary>
+        /// Gets the provider type value used to identify specific provider origins later on when reading back existing issues.
+        /// </summary>
+        /// <param name="thread">Thread to get the value from.</param>
+        /// <returns>Comment source value.</returns>
+        public static string GetProviderType(this AzureDevOpsPullRequestCommentThread thread)
+        {
+            thread.NotNull(nameof(thread));
+
+            return thread.GetValue<string>(ProviderTypePropertyName);
+        }
+
+        /// <summary>
+        /// Sets the provider type value used to identify specific provider origins later on when reading back existing issues.
+        /// </summary>
+        /// <param name="thread">Thread for which the value should be set.</param>
+        /// <param name="value">Value to set as comment source.</param>
+        public static void SetProviderType(this AzureDevOpsPullRequestCommentThread thread, string value)
+        {
+            thread.NotNull(nameof(thread));
+
+            thread.SetValue(ProviderTypePropertyName, value);
         }
     }
 }


### PR DESCRIPTION
**What I've done:**

From now on everytime Cake.Issues will report to a AzureDevops PullRequest, all comment thread will retrieve a new custom property `ProviderType`, which is persisted in AzureDevops. When existing issues are read, the information will be stored into the `IPullRequestDiscussionThread.ProviderType` property, which will be used later on to filter the existing threads by provider type.

Additionallly I've added a few new configuration options, that varied from the Analyzers configuration set, to the resharper solution settings. (this qualifier for fields + properties, usings in deepest scope...)

Closes #182 