### PR TITLE
Added EndLine, Column and EndColumn information to the CodeFlow properties, when filled

### DIFF
--- a/src/Cake.Issues.PullRequests.AzureDevOps/AzureDevOpsPullRequestSystem.cs
+++ b/src/Cake.Issues.PullRequests.AzureDevOps/AzureDevOpsPullRequestSystem.cs
@@ -114,9 +114,9 @@
 
             properties.Add("Microsoft.VisualStudio.Services.CodeReview.ItemPath", "/" + issue.AffectedFileRelativePath);
             properties.Add("Microsoft.VisualStudio.Services.CodeReview.Right.StartLine", issue.Line);
-            properties.Add("Microsoft.VisualStudio.Services.CodeReview.Right.EndLine", issue.Line);
-            properties.Add("Microsoft.VisualStudio.Services.CodeReview.Right.StartOffset", 0);
-            properties.Add("Microsoft.VisualStudio.Services.CodeReview.Right.EndOffset", 1);
+            properties.Add("Microsoft.VisualStudio.Services.CodeReview.Right.EndLine", issue.EndLine ?? issue.Line);
+            properties.Add("Microsoft.VisualStudio.Services.CodeReview.Right.StartOffset", issue.Column ?? 0);
+            properties.Add("Microsoft.VisualStudio.Services.CodeReview.Right.EndOffset", issue.EndColumn ?? 1);
             properties.Add("Microsoft.VisualStudio.Services.CodeReview.FirstComparingIteration", iterationId);
             properties.Add("Microsoft.VisualStudio.Services.CodeReview.SecondComparingIteration", iterationId);
             properties.Add("Microsoft.VisualStudio.Services.CodeReview.ChangeTrackingId", changeTrackingId);


### PR DESCRIPTION
I've added `EndLine`, `Column` and `EndColumn` information to the CodeFlow properties.
If the information is not existent, it will fall back to the values, that are currently assigned.

Resolves #203 and #204 