### PR TITLE
Disable reporting to Coveralls

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+    "sdk": {
+        "allowPrerelease": true,
+        "version": "6.0.100",
+        "rollForward": "latestFeature"
+    }
+}

--- a/recipe.cake
+++ b/recipe.cake
@@ -30,4 +30,7 @@ ToolSettings.SetToolPreprocessorDirectives(
     reSharperTools: "#tool nuget:?package=JetBrains.ReSharper.CommandLineTools&version=2021.3.1",
     gitVersionGlobalTool: "#tool dotnet:?package=GitVersion.Tool&version=5.8.1");
 
+// Disable Upload-Coveralls-Report task since it fails to install the tool on AppVeyor
+BuildParameters.Tasks.UploadCoverallsReportTask.WithCriteria(() => false);
+
 Build.RunDotNetCore();


### PR DESCRIPTION
Disables reporting to Coveralls, since it fails to restore the tool on AppVeyor